### PR TITLE
Show full error message within disclosure. Fixes #75

### DIFF
--- a/public/css/milligram.css
+++ b/public/css/milligram.css
@@ -184,6 +184,7 @@ pre {
   background: #ECF0F1;
   border-left: 0.3rem solid #2980B9;
   overflow-y: hidden;
+  white-space: pre-wrap;
 }
 
 pre > code {

--- a/views/site_overview.erb
+++ b/views/site_overview.erb
@@ -29,6 +29,11 @@
   </div>
 <% else %>
   <table>
+    <colgroup>
+      <col style="width: 25%">
+      <col style="width: 15%">
+      <col style="width: 60%">
+    </colgroup>
   <% @site.log.each do |entry| %>
     <tr class="<% entry[:url] ? 'post' : 'error' %>">
       <th>
@@ -42,7 +47,10 @@
         <% if entry[:url] %>
           <a href="<%= entry[:url] %>"><%= entry[:url] %></a>
         <% else %>
-          <span title="<%= entry[:error]['error_description'] %>"><code><%= entry[:error]['error'] %></code> error</span>
+          <details>
+            <summary><code><%= entry[:error]['error'] %></code> error</summary>
+            <pre><%= entry[:error]['error_description'] %></pre>
+          </details>
         <% end %>
       </td>
     </tr>


### PR DESCRIPTION
I wasn’t aware that the full error message was available, being somewhat inaccessible via the `title` attribute. This PR makes a small change to show the full message within a disclosure.

I’m using `details` and `summary` elements here. For wider (i.e. IE11) browser support, we would need to provide additional JavaScript fallback behaviour. But in the spirit of 🤠, this is a nice quick fix, I hope!